### PR TITLE
Bug 325937 - Make selected part more visible (win)

### DIFF
--- a/bundles/org.eclipse.ui.themes/css/e4_default_win7.css
+++ b/bundles/org.eclipse.ui.themes/css/e4_default_win7.css
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Lars Vogel <Lars.Vogel@gmail.com> - Bug 420836
+ *     Frank Appel <fappel@codeaffine.com> - Bug 325937
  *******************************************************************************/
 
 @import url("platform:/plugin/org.eclipse.ui.themes/css/e4_basestyle.css");
@@ -21,7 +22,31 @@ ColorDefinition#org-eclipse-ui-workbench-ACTIVE_UNSELECTED_TABS_COLOR_END {
 }
 
 ColorDefinition#org-eclipse-ui-workbench-ACTIVE_TAB_OUTER_KEYLINE_COLOR {
-	color: #B6BCCC;
+	color: #CCCCCC;
+}
+
+ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_START {
+	color: #F4F6FC;
+}
+
+ColorDefinition#org-eclipse-ui-workbench-INACTIVE_UNSELECTED_TABS_COLOR_END {
+	color: #F4F6FC;
+}
+
+ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTER_KEYLINE_COLOR {
+	color: #FFFFFF;
+}
+
+ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_OUTLINE_COLOR {
+	color: #CED5E5;
+}
+
+ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_START {
+	color: #D5E1ED;
+}
+
+ColorDefinition#org-eclipse-ui-workbench-INACTIVE_TAB_BG_END {
+	color: #FFFFFF;
 }
 
 .MTrimmedWindow {


### PR DESCRIPTION
changes on e4_default_win7:

* reduce contrast on inactive tab gradient
* reduce contrast between inactive tab and unselected inactive tabs by the use of a light blue background color

These changes intent to make the inactive part stacks appear less prominent and hence put more emphasize on the active stack/part